### PR TITLE
Pckroon trust constr

### DIFF
--- a/symfit/core/minimizers.py
+++ b/symfit/core/minimizers.py
@@ -186,7 +186,7 @@ class HessianMinimizer(GradientMinimizer):
             # Make two dimensional, corresponding to a scalar function.
             out = np.atleast_2d(np.squeeze(out))
             mask = [p not in self._fixed_params for p in self.parameters]
-            return out[mask, mask]
+            return np.atleast_2d(out[mask, mask])
         return resized
 
 
@@ -573,11 +573,10 @@ class TrustConstr(ScipyHessianMinimize, ScipyConstrainedMinimize, BoundedMinimiz
                 ub = 0
             else:
                 ub = np.inf
-            tc_con = NonlinearConstraint(fun=con['fun'],
-                                         lb=0, ub=ub,
-                                         jac=con['jac'],
-                                         hess=con['hess'],
-                                         )
+            tc_con = NonlinearConstraint(
+                fun=con['fun'], lb=0, ub=ub, jac=con['jac'],
+                hess=lambda x, v: con['hess'](x) * v,
+            )
             out.append(tc_con)
         return out
 

--- a/symfit/core/minimizers.py
+++ b/symfit/core/minimizers.py
@@ -156,7 +156,7 @@ class GradientMinimizer(BaseMinimizer):
 
 class HessianMinimizer(GradientMinimizer):
     """
-    ABC for Minizers that support the use of a Hessian.
+    ABC for Minimizer's that support the use of a Hessian.
     """
     @keywordonly(hessian=None)
     def __init__(self, *args, **kwargs):

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -435,8 +435,8 @@ class Tests(unittest.TestCase):
         fit = Fit(g, xdata, ydata)
         fit_result = fit.execute()
 
-        self.assertAlmostEqual(fit_result.value(A)/5, 1.0, 6)
-        self.assertAlmostEqual(np.abs(fit_result.value(sig)), 1.0, 6)
+        self.assertAlmostEqual(fit_result.value(A), 5.0)
+        self.assertAlmostEqual(np.abs(fit_result.value(sig)), 1.0)
         self.assertAlmostEqual(fit_result.value(x0), 0.0)
         # raise Exception([i for i in fit_result.params])
         sexy = g(x=2.0, **fit_result.params)
@@ -617,7 +617,7 @@ class Tests(unittest.TestCase):
 
         self.assertAlmostEqual(fit_result.value(mu) / mean, 1, 6)
         self.assertAlmostEqual(fit_result.stdev(mu) / mean_stdev, 1, 3)
-        self.assertAlmostEqual(fit_result.value(sig) / np.std(xdata), 1, 5)
+        self.assertAlmostEqual(fit_result.value(sig) / np.std(xdata), 1, 6)
 
     def test_evaluate_model(self):
         """

--- a/tests/test_minimizers.py
+++ b/tests/test_minimizers.py
@@ -12,7 +12,7 @@ from symfit import (
     Model, FitResults, variables, CallableNumericalModel, Constraint
 )
 from symfit.core.minimizers import *
-from symfit.core.support import partial
+from symfit.core.objectives import LeastSquares
 
 # Defined at the global level because local functions can't be pickled.
 def f(x, a, b):
@@ -129,8 +129,10 @@ class TestMinimize(unittest.TestCase):
         xdata = np.linspace(0, 10)
         ydata = model(x=xdata, a=5.5, b=15.0).y + np.random.normal(0, 1)
         fit = Fit({y: a * x + b}, x=xdata, y=ydata, minimizer=TrustConstr)
-        self.assertNotEqual(fit.minimizer.jacobian, None)
-        self.assertNotEqual(fit.minimizer.hessian, None)
+        self.assertIsInstance(fit.minimizer.objective, LeastSquares)
+        self.assertIsInstance(fit.minimizer.jacobian.__self__, LeastSquares)
+        self.assertIsInstance(fit.minimizer.hessian.__self__, LeastSquares)
+
         fit_result = fit.execute()
         self.assertAlmostEqual(fit_result.value(b), 1.0)
 
@@ -156,9 +158,7 @@ class TestMinimize(unittest.TestCase):
         constrained_minimizers = subclasses(ScipyConstrainedMinimize)
         # Test for all of them if they can be pickled.
         for minimizer in scipy_minimizers:
-            # TrustConstr's constraints are wildly different
-            # TODO: Actually fix the tests in that case
-            if minimizer in constrained_minimizers and not minimizer is TrustConstr:
+            if minimizer in constrained_minimizers:
                 constraints = [Ge(b, a)]
             else:
                 constraints = []
@@ -168,6 +168,9 @@ class TestMinimize(unittest.TestCase):
             )
             fit = Fit(model, x=xdata, y=ydata, minimizer=minimizer,
                       constraints=constraints)
+            self.assertIsInstance(fit.objective, LeastSquares)
+            self.assertIsInstance(fit.minimizer.objective, LeastSquares)
+
             fit = fit.minimizer  # Just check if the minimizer pickles
             dump = pickle.dumps(fit)
             pickled_fit = pickle.loads(dump)
@@ -203,10 +206,33 @@ class TestMinimize(unittest.TestCase):
                                     self.assertEqual(val1.model.__signature__,
                                                      val2.model.__signature__)
                                 elif key == 'wrapped_constraints':
-                                    self.assertEqual(val1['type'],
-                                                     val2['type'])
-                                    self.assertEqual(set(val1.keys()),
-                                                     set(val2.keys()))
+                                    if isinstance(val1, dict):
+                                        self.assertEqual(val1['type'],
+                                                         val2['type'])
+                                        self.assertEqual(set(val1.keys()),
+                                                         set(val2.keys()))
+                                    elif isinstance(val1, NonlinearConstraint):
+                                        # For trust-ncg we manually check if
+                                        # their dicts are equal, because no
+                                        # __eq__ is implemented on
+                                        # NonLinearConstraint
+                                        self.assertEqual(len(val1.__dict__),
+                                                         len(val2.__dict__))
+                                        for key in val1.__dict__:
+                                            try:
+                                                self.assertEqual(
+                                                    val1.__dict__[key],
+                                                    val2.__dict__[key]
+                                                )
+                                            except AssertionError:
+                                                self.assertIsInstance(
+                                                    val1.__dict__[key],
+                                                    val2.__dict__[key].__class__
+                                                )
+                                    else:
+                                        raise NotImplementedError(
+                                            'No such constraint type is known.'
+                                        )
                         elif key == '_pickle_kwargs':
                             FitResults._array_safe_dict_eq(value, new_value)
                         else:

--- a/tests/test_minimizers.py
+++ b/tests/test_minimizers.py
@@ -12,7 +12,7 @@ from symfit import (
     Model, FitResults, variables, CallableNumericalModel, Constraint
 )
 from symfit.core.minimizers import *
-from symfit.core.objectives import LeastSquares
+from symfit.core.objectives import LeastSquares, VectorLeastSquares
 
 # Defined at the global level because local functions can't be pickled.
 def f(x, a, b):
@@ -168,8 +168,12 @@ class TestMinimize(unittest.TestCase):
             )
             fit = Fit(model, x=xdata, y=ydata, minimizer=minimizer,
                       constraints=constraints)
-            self.assertIsInstance(fit.objective, LeastSquares)
-            self.assertIsInstance(fit.minimizer.objective, LeastSquares)
+            if minimizer is not MINPACK:
+                self.assertIsInstance(fit.objective, LeastSquares)
+                self.assertIsInstance(fit.minimizer.objective, LeastSquares)
+            else:
+                self.assertIsInstance(fit.objective, VectorLeastSquares)
+                self.assertIsInstance(fit.minimizer.objective, VectorLeastSquares)
 
             fit = fit.minimizer  # Just check if the minimizer pickles
             dump = pickle.dumps(fit)


### PR DESCRIPTION
Added pickle testing for trust Constr, and some other minor improvements to tests.

This raised a new bug:
```python
Ran 1 test in 0.027s

FAILED (errors=1)

Error
Traceback (most recent call last):
  File "C:\ProgramData\Miniconda3\lib\unittest\case.py", line 59, in testPartExecutor
    yield
  File "C:\ProgramData\Miniconda3\lib\unittest\case.py", line 615, in run
    testMethod()
  File "C:\Users\u0114255\stack\Code\symfit debug\symfit\tests\test_minimizers.py", line 252, in test_pickle
    res_before = fit.execute()
  File "c:\users\u0114255\stack\code\symfit debug\symfit\symfit\core\support.py", line 356, in wrapped_func
    return func(*bound_args.args, **bound_args.kwargs)
  File "c:\users\u0114255\stack\code\symfit debug\symfit\symfit\core\minimizers.py", line 619, in execute
    **minimize_options)
  File "c:\users\u0114255\stack\code\symfit debug\symfit\symfit\core\support.py", line 356, in wrapped_func
    return func(*bound_args.args, **bound_args.kwargs)
  File "c:\users\u0114255\stack\code\symfit debug\symfit\symfit\core\minimizers.py", line 434, in execute
    return super(ScipyHessianMinimize, self).execute(hessian=hessian, **minimize_options)
  File "c:\users\u0114255\stack\code\symfit debug\symfit\symfit\core\support.py", line 356, in wrapped_func
    return func(*bound_args.args, **bound_args.kwargs)
  File "c:\users\u0114255\stack\code\symfit debug\symfit\symfit\core\minimizers.py", line 411, in execute
    return super(ScipyGradientMinimize, self).execute(jacobian=jacobian, **minimize_options)
  File "c:\users\u0114255\stack\code\symfit debug\symfit\symfit\core\minimizers.py", line 453, in execute
    return super(ScipyConstrainedMinimize, self).execute(constraints=self.wrapped_constraints, **minimize_options)
  File "c:\users\u0114255\stack\code\symfit debug\symfit\symfit\core\support.py", line 356, in wrapped_func
    return func(*bound_args.args, **bound_args.kwargs)
  File "c:\users\u0114255\stack\code\symfit debug\symfit\symfit\core\minimizers.py", line 345, in execute
    **minimize_options
  File "C:\ProgramData\Miniconda3\lib\site-packages\scipy\optimize\_minimize.py", line 615, in minimize
    callback=callback, **options)
  File "C:\ProgramData\Miniconda3\lib\site-packages\scipy\optimize\_trustregion_constr\minimize_trustregion_constr.py", line 332, in _minimize_trustregion_constr
    for c in constraints]
  File "C:\ProgramData\Miniconda3\lib\site-packages\scipy\optimize\_trustregion_constr\minimize_trustregion_constr.py", line 332, in <listcomp>
    for c in constraints]
  File "C:\ProgramData\Miniconda3\lib\site-packages\scipy\optimize\_constraints.py", line 211, in __init__
    finite_diff_bounds, sparse_jacobian)
  File "C:\ProgramData\Miniconda3\lib\site-packages\scipy\optimize\_differentiable_functions.py", line 344, in __init__
    self.H = hess(self.x, self.v)
  File "c:\users\u0114255\stack\code\symfit debug\symfit\symfit\core\minimizers.py", line 187, in resized
    out = func(*args, **kwargs)
TypeError: eval_hessian() takes from 1 to 2 positional arguments but 3 were given
```
It seems to be coming from trust-constr evaluating it's constraints, and feeding to many parameters to our MinimizeModel.eval_hessian, eventhough I checked the signature for this object and it is correct, and identical to that of MinimizeModel.eval_jacobian...